### PR TITLE
Avoid adding enumerable members to global prototypes.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -81,12 +81,21 @@ exports.responds = function(that, name) {
     return (that[name] && typeof that[name] === 'function');
 };
 
+function defineProperty(obj, key, val) {
+  Object.defineProperty(obj, key, {
+    value: val,
+    writable: true,
+    configurable: true,
+    enumerable: false
+  });
+}
+
 /**
  * once()
  * Returns a function that will call the underlying function only once
  * whether it is called once or multiple times 
  */
-Function.prototype.once = function() {
+defineProperty(Function.prototype, 'once', function() {
   var fn = this;
   var done = false;
   return function() {    
@@ -96,21 +105,25 @@ Function.prototype.once = function() {
       fn.apply(null, args);
     }
   };
-};
+});
 
-/** 
- * bind()
- * The .bind method from Prototype.js 
- */
-Function.prototype.bind = function() {
-  var fn = this, 
-  args = Array.prototype.slice.call(arguments), 
-  object = args.shift(); 
-  return function(){    
-    return fn.apply(object, 
-                    args.concat(Array.prototype.slice.call(arguments))); 
-  };
-};
+if (!Function.prototype.bind) {
+  // The V8 .bind is much, much faster than this, only define this bind if it
+  // does not exist.
+  /**
+   * bind()
+   * The .bind method from Prototype.js
+   */
+  defineProperty(Function.prototype, 'bind', function() {
+    var fn = this,
+    args = Array.prototype.slice.call(arguments),
+    object = args.shift();
+    return function() {
+      return fn.apply(object,
+                      args.concat(Array.prototype.slice.call(arguments)));
+    };
+  });
+}
 
 /** 
  * remove(e)
@@ -226,12 +239,12 @@ exports.forEach = function(that, fun /*, thisp */) {
  * trim() ltrim() rtrim()
  * String trim functions
  */
-String.prototype.trim = function() {
+defineProperty(String.prototype, 'trim', function() {
   return this.replace(/^\s+|\s+$/g,"");
-};
-String.prototype.ltrim = function() {
+});
+defineProperty(String.prototype, 'ltrim', function() {
   return this.replace(/^\s+/,"");
-};
-String.prototype.rtrim = function() {
+});
+defineProperty(String.prototype, 'rtrim', function() {
   return this.replace(/\s+$/,"");
-};
+});


### PR DESCRIPTION
Avoid adding enumerable members to global prototypes, this breaks other modules.
Avoid re-defining Function.prototype.bind - the native version V8 includes is much, much faster.
