### PR TITLE
moving "should" to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   "repository" :    { "type" :  "git",
                       "url" :   "http://github.com/teleportd/fwk.git" },
   "dependencies": {
-    "should": "0.6.x",
     "async": "0.2.x"
+  },
+  "devDependencies": {
+    "should": "0.6.x"
   },
   "main" : "./lib/fwk",
   "engines" : { "node" : ">=0.8.0" }


### PR DESCRIPTION
I have "should" package in my devDependencies (it is for tests, like in your package) and I use instagram-node that depends on fwk.

Your package uses should 0.6.x and mine - ^8.1.1, so I just can't do `npm shrinkwrap` in my package.

"should" is not for production.

Please merge and release a patch version.
